### PR TITLE
Update apache on vhost change

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -15,7 +15,6 @@ define apache::vhost(
   $docroot  = undef,
   $host = undef,
 ) {
-  require apache
 
   $vhost_docroot = $docroot ? {
     undef   => "${boxen::config::srcdir}/${name}",
@@ -30,7 +29,7 @@ define apache::vhost(
   file { "${apache::config::sitesdir}/${name}.conf":
     content => template('apache/config/apache/vhost.conf.erb'),
     require => File[$apache::config::sitesdir],
-    #notify  => Service['org.apache.httpd'],
+    notify  => Service['org.apache.httpd'],
   }
 
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -15,6 +15,7 @@ define apache::vhost(
   $docroot  = undef,
   $host = undef,
 ) {
+  include apache
 
   $vhost_docroot = $docroot ? {
     undef   => "${boxen::config::srcdir}/${name}",


### PR DESCRIPTION
Instead of "require apache" for vhosts, we can notify apache of vhost. So we avoid dependency cycles. As vhosts only do work with apache enabled, that should be fine I think.
